### PR TITLE
Update django.po

### DIFF
--- a/diacamma/syndic/locale/fr/LC_MESSAGES/django.po
+++ b/diacamma/syndic/locale/fr/LC_MESSAGES/django.po
@@ -65,4 +65,4 @@ msgstr "dépenses"
 
 #: migrations/0001_initial.py:46
 msgid "revenue"
-msgstr "revenue"
+msgstr "revenu"


### PR DESCRIPTION
La traduction correcte en français pour "revenue" est le "revenu"