### PR TITLE
Update belgium.py

### DIFF
--- a/diacamma/condominium/system/belgium.py
+++ b/diacamma/condominium/system/belgium.py
@@ -46,7 +46,7 @@ class BelgiumSystemCondo(DefaultSystemCondo):
         Parameter.change_value('condominium-default-owner-account1', correct_accounting_code('410100'))
         Parameter.change_value('condominium-default-owner-account2', correct_accounting_code('410000'))
         Parameter.change_value('condominium-default-owner-account3', correct_accounting_code('410100'))
-        Parameter.change_value('condominium-default-owner-account4', correct_accounting_code(''))
+        Parameter.change_value('condominium-default-owner-account4', correct_accounting_code('410100'))
         Parameter.change_value('condominium-default-owner-account5', correct_accounting_code('410000'))
         Parameter.change_value('condominium-current-revenue-account', correct_accounting_code('701100'))
         Parameter.change_value('condominium-exceptional-revenue-account', correct_accounting_code('700100'))


### PR DESCRIPTION
Bug "double comptage" confirmé et ... solutions proposées. Il faut préciser qu'il s'agit d'un bug belge ! :-)

L'absence de code comptable pour 'condominium-default-owner-account4' dans la version syndic belge, provoque une mauvaise requête sql dans la méthode 'Owner.get_total_initial()'.
De ce fait, la méthode 'Owner.check_initial_operation()' génère une double entrée dans la table 'condominium_calldetail' (lorsque le montant est négatif). La première entrée est correcte (type_call=0) mais la seconde est erronée (type_call=3). Par la suite, diverses erreurs d'appels de fonds se produisent, uniquement dans la partie 'Copropriété', telle celle rapportée sue le forum Diacamma:  [Bug double comptage de règlement ?](https://www.diacamma.org/forum/syndic-de-copropriete/1146-bug-double-comptage-de-reglement)

Solution pour les nouvelles instances syndic belge:
- Dans le fichier 'belgium.py', donner un code comptable à 'condominium-default-owner-account4'. A priori, n'importe quel code car il semble ne jamais être utilisé (à vérifier).
- Une autre solution consisterait à traiter une absence de code comptable comme un doublon implicite dans Owner.is_owner_account_doubled().

Solution pour les bases de données existantes:
- Dans la table 'condominium_calldetail', supprimer les secondes lignes des doublons, celles avec 'type_call' = 3.
- Dans la table 'CORE_parameters', mettre un code comptable face au champ 'condominium-default-owner-account4'.

Merci pour tout,
Louis